### PR TITLE
Forward approveFunction on provider calls

### DIFF
--- a/src/RelayClient.js
+++ b/src/RelayClient.js
@@ -446,7 +446,8 @@ class RelayClient {
             to: params.to,
             txfee: params.txFee || params.txfee || relayClientOptions.txfee,
             gas_limit: params.gas && parseInt(params.gas, 16),
-            gas_price: params.gasPrice && parseInt(params.gasPrice, 16)
+            gas_price: params.gasPrice && parseInt(params.gasPrice, 16),
+            approveFunction: params.approveFunction
         };
 
         if (relayClientOptions.verbose)


### PR DESCRIPTION
Fixes https://github.com/OpenZeppelin/openzeppelin-gsn-provider/issues/9

This simply forwards an `approveFunction` from the provider into the client, which already knows how to handle those.

The issue also mentioned renaming the function and the object it receives, but we may want to leave that for https://github.com/OpenZeppelin/openzeppelin-gsn-provider/issues/10.