### PR TITLE
Optimize filtering of RelayHub events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,8 @@
   "dependencies": {
     "@openzeppelin/gsn-helpers": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/gsn-helpers/-/gsn-helpers-0.1.4.tgz",
+      "integrity": "sha512-RELmLAI5FZMkmszBcryBLAvgi6YRTKjOyeLVZVNP+Cg0ZqfDGSGKG85yuplMgRyMtqh5wPDf5Ah5YiCFjrjVfw==",
       "dev": true,
       "requires": {
         "axios": "^0.19.0",
@@ -14,6 +16,14 @@
         "lodash": "^4.17.15",
         "sleep-promise": "^8.0.1",
         "web3": "^1.2.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+          "dev": true
+        }
       }
     },
     "@sindresorhus/is": {
@@ -5621,6 +5631,12 @@
         }
       }
     },
+    "sleep-promise": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/sleep-promise/-/sleep-promise-8.0.1.tgz",
+      "integrity": "sha1-jXlaJ+ojlT32tSuRCB5eImZZk8U=",
+      "dev": true
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -7047,32 +7063,6 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
           "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
         },
-        "web3-utils": {
-          "version": "1.0.0-beta.37",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.37.tgz",
-          "integrity": "sha512-kA1fyhO8nKgU21wi30oJQ/ssvu+9srMdjOTKbHYbQe4ATPcr5YNwwrxG3Bcpbu1bEwRUVKHCkqi+wTvcAWBdlQ==",
-          "requires": {
-            "bn.js": "4.11.6",
-            "eth-lib": "0.1.27",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randomhex": "0.1.5",
-            "underscore": "1.8.3",
-            "utf8": "2.1.1"
-          }
-        }
-      }
-    },
-    "web3-eth-abi": {
-      "version": "1.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.37.tgz",
-      "integrity": "sha512-g9DKZGM2OqwKp/tX3W/yihcj7mQCtJ6CXyZXEIZfuDyRBED/iSEIFfieDOd+yo16sokLMig6FG7ADhhu+19hdA==",
-      "requires": {
-        "ethers": "4.0.0-beta.1",
-        "underscore": "1.8.3",
-        "web3-utils": "1.0.0-beta.37"
-      },
-      "dependencies": {
         "elliptic": {
           "version": "6.3.3",
           "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
@@ -7110,16 +7100,6 @@
             "minimalistic-assert": "^1.0.0"
           }
         },
-        "js-sha3": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
-        },
-        "scrypt-js": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
-          "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
-        },
         "setimmediate": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
@@ -7129,6 +7109,16 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
           "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+        },
+        "web3-eth-abi": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.37.tgz",
+          "integrity": "sha512-g9DKZGM2OqwKp/tX3W/yihcj7mQCtJ6CXyZXEIZfuDyRBED/iSEIFfieDOd+yo16sokLMig6FG7ADhhu+19hdA==",
+          "requires": {
+            "ethers": "4.0.0-beta.1",
+            "underscore": "1.8.3",
+            "web3-utils": "1.0.0-beta.37"
+          }
         },
         "web3-utils": {
           "version": "1.0.0-beta.37",
@@ -7142,14 +7132,24 @@
             "randomhex": "0.1.5",
             "underscore": "1.8.3",
             "utf8": "2.1.1"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.11.6",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-            }
           }
+        }
+      }
+    },
+    "web3-eth-abi": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.1.tgz",
+      "integrity": "sha512-jI/KhU2a/DQPZXHjo2GW0myEljzfiKOn+h1qxK1+Y9OQfTcBMxrQJyH5AP89O6l6NZ1QvNdq99ThAxBFoy5L+g==",
+      "requires": {
+        "ethers": "4.0.0-beta.3",
+        "underscore": "1.9.1",
+        "web3-utils": "1.2.1"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+          "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
         }
       }
     },
@@ -7242,6 +7242,63 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
           "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
         },
+        "elliptic": {
+          "version": "6.3.3",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
+          "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "inherits": "^2.0.1"
+          }
+        },
+        "ethers": {
+          "version": "4.0.0-beta.1",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.1.tgz",
+          "integrity": "sha512-SoYhktEbLxf+fiux5SfCEwdzWENMvgIbMZD90I62s4GZD9nEjgEWy8ZboI3hck193Vs0bDoTohDISx84f2H2tw==",
+          "requires": {
+            "@types/node": "^10.3.2",
+            "aes-js": "3.0.0",
+            "bn.js": "^4.4.0",
+            "elliptic": "6.3.3",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.3",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          }
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "setimmediate": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+        },
+        "web3-eth-abi": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.37.tgz",
+          "integrity": "sha512-g9DKZGM2OqwKp/tX3W/yihcj7mQCtJ6CXyZXEIZfuDyRBED/iSEIFfieDOd+yo16sokLMig6FG7ADhhu+19hdA==",
+          "requires": {
+            "ethers": "4.0.0-beta.1",
+            "underscore": "1.8.3",
+            "web3-utils": "1.0.0-beta.37"
+          }
+        },
         "web3-utils": {
           "version": "1.0.0-beta.37",
           "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.37.tgz",
@@ -7277,6 +7334,63 @@
           "version": "4.11.6",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
           "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        },
+        "elliptic": {
+          "version": "6.3.3",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
+          "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "inherits": "^2.0.1"
+          }
+        },
+        "ethers": {
+          "version": "4.0.0-beta.1",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.1.tgz",
+          "integrity": "sha512-SoYhktEbLxf+fiux5SfCEwdzWENMvgIbMZD90I62s4GZD9nEjgEWy8ZboI3hck193Vs0bDoTohDISx84f2H2tw==",
+          "requires": {
+            "@types/node": "^10.3.2",
+            "aes-js": "3.0.0",
+            "bn.js": "^4.4.0",
+            "elliptic": "6.3.3",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.3",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          }
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "setimmediate": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+        },
+        "web3-eth-abi": {
+          "version": "1.0.0-beta.37",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.37.tgz",
+          "integrity": "sha512-g9DKZGM2OqwKp/tX3W/yihcj7mQCtJ6CXyZXEIZfuDyRBED/iSEIFfieDOd+yo16sokLMig6FG7ADhhu+19hdA==",
+          "requires": {
+            "ethers": "4.0.0-beta.1",
+            "underscore": "1.8.3",
+            "web3-utils": "1.0.0-beta.37"
+          }
         },
         "web3-utils": {
           "version": "1.0.0-beta.37",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "ethereumjs-util": "^6.1.0",
     "ethereumjs-wallet": "^0.6.3",
     "web3": "^1.2.0",
+    "web3-eth-abi": "^1.2.1",
     "web3-utils": "^1.2.0"
   },
   "devDependencies": {

--- a/src/tabookey-gasless/ServerHelper.js
+++ b/src/tabookey-gasless/ServerHelper.js
@@ -1,4 +1,5 @@
 const BN = require('web3').utils.toBN;
+const abi = require('web3-eth-abi');
 
 //relays are "down-scored" in case they timed out a request.
 // they are "forgiven" after this timeout.
@@ -193,6 +194,10 @@ class ServerHelper {
             this.filteredRelays = []
         }
         this.relayHubInstance = relayHubInstance
+        this.addedAndRemovedSignatures = 
+            this.relayHubInstance.options.jsonInterface.filter(e =>
+                e.name === 'RelayAdded' || e.name === 'RelayRemoved'
+            ).map(abi.encodeEventSignature);
     }
 
     async newActiveRelayPinger(fromBlock, gasPrice ) {
@@ -219,7 +224,7 @@ class ServerHelper {
         let activeRelays = {}
         let fromBlock = this.fromBlock || 2;
         let addedAndRemovedEvents = await this.relayHubInstance.getPastEvents("allEvents", { fromBlock: fromBlock,
-            // topics: [["RelayAdded", "RelayRemoved"]]
+            topics: [this.addedAndRemovedSignatures],
         })
 
         if (this.verbose){

--- a/src/tabookey-gasless/ServerHelper.js
+++ b/src/tabookey-gasless/ServerHelper.js
@@ -223,7 +223,8 @@ class ServerHelper {
     async fetchRelaysAdded() {
         let activeRelays = {}
         let fromBlock = this.fromBlock || 2;
-        let addedAndRemovedEvents = await this.relayHubInstance.getPastEvents("allEvents", { fromBlock: fromBlock,
+        let addedAndRemovedEvents = await this.relayHubInstance.getPastEvents("allEvents", {
+            fromBlock: fromBlock,
             topics: [this.addedAndRemovedSignatures],
         })
 

--- a/test/GSNProvider.test.js
+++ b/test/GSNProvider.test.js
@@ -527,6 +527,9 @@ describe('GSNProvider', function () {
 
     beforeEach('creating provider', async function () {
       this.gsnProvider = new GSNProvider(PROVIDER_URL, HARDCODED_RELAYER_OPTS);
+
+      // it's necessary to send a transaction through the gsnProvider for the serverHelper
+      // to get hold of an instance of the relayHub
       this.greeter.setProvider(this.gsnProvider);
       await this.greeter.methods.greet("Hello").send({ from: this.sender, useGSN: true });
     });

--- a/test/GSNProvider.test.js
+++ b/test/GSNProvider.test.js
@@ -37,6 +37,7 @@ describe('GSNProvider', function () {
     this.deployer = this.accounts[0];
     this.sender = this.accounts[1];
     this.signer = this.accounts[2];
+    this.secondRelay = this.accounts[6];
     this.failsPre = this.accounts[7];
     this.failsPost = this.accounts[8];
   });
@@ -517,6 +518,59 @@ describe('GSNProvider', function () {
       await expect(sendTx.call(this, greeter)).to.be.rejectedWith(/no relayer.+canRelay check failed with error 20/is);
     });
 
+  });
+
+  context('detecting relays added', function () {
+    before('getting relayHub', async function () {
+      this.relayHub = await getRelayHub(this.web3);
+    });
+
+    beforeEach('creating provider', async function () {
+      this.gsnProvider = new GSNProvider(PROVIDER_URL, HARDCODED_RELAYER_OPTS);
+      this.greeter.setProvider(this.gsnProvider);
+      await this.greeter.methods.greet("Hello").send({ from: this.sender, useGSN: true });
+    });
+
+    it('finds the one relay added', async function () {
+      const relays = await this.gsnProvider.relayClient.serverHelper.fetchRelaysAdded();
+      expect(relays).to.have.lengthOf(1);
+    });
+
+    context('with a second relay added', async function () {
+      beforeEach('adding second relay', async function () {
+        await this.relayHub.methods.stake(this.secondRelay, 60*60*24*10 /* 10 days */)
+          .send({
+            value: Web3.utils.toWei('1', 'ether'),
+            from: this.deployer,
+            useGSN: false,
+          });
+        await this.relayHub.methods.registerRelay(0, 'url')
+          .send({
+            from: this.secondRelay,
+            useGSN: false,
+          });
+      });
+
+      it('finds the two relays', async function () {
+        const relays = await this.gsnProvider.relayClient.serverHelper.fetchRelaysAdded();
+        expect(relays).to.have.lengthOf(2);
+      });
+
+      context('with the second relay removed', async function () {
+        beforeEach('removing second relay', async function () {
+          await this.relayHub.methods.removeRelayByOwner(this.secondRelay)
+            .send({
+              from: this.deployer,
+              useGSN: false,
+            });
+        });
+
+        it('finds only one relay', async function () {
+          const relays = await this.gsnProvider.relayClient.serverHelper.fetchRelaysAdded();
+          expect(relays).to.have.lengthOf(1);
+        });
+      });
+    });
   });
 });
 


### PR DESCRIPTION
Fixes #14.

Previously we were retrieving all of the events instead of asking the node for only `RelayAdded` and `RelayRemoved` events.