### PR TITLE
Fix callData not enought gasLeft issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/gsn-provider",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Web3 provider for GSN",
   "main": "src/index.js",
   "scripts": {

--- a/src/dev/DevRelayClient.js
+++ b/src/dev/DevRelayClient.js
@@ -8,6 +8,7 @@ const {
   createRelayHubFromRecipient,
 } = require('../utils');
 const { getTransactionHash, getTransactionSignature } = require('../tabookey-gasless/utils');
+const { getCallDataGas } = require('../utils');
 
 const TARGET_BALANCE = 2e18;
 const MIN_BALANCE = 2e17;
@@ -75,7 +76,9 @@ class DevRelayClient {
     await this.validateCanRelay(hub, txParams, gasPrice, gas, nonce, signature, approvalData);
     if (this.debug) console.log(`Can relay check succeeded`);
 
-    const requiredGas = await hub.methods.requiredGas(gas.toString()).call();
+    const requiredGas = BN(await hub.methods.requiredGas(gas.toString()).call())
+      .plus(getCallDataGas(txParams.data))
+      .toString();
     if (this.debug) console.log(`Relaying transaction with gas ${requiredGas}`);
 
     return new Promise((resolve, reject) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -178,6 +178,24 @@ async function getRecipientFunds(web3, recipientAddr) {
   return await relayHub.methods.balanceOf(recipientAddr).call();
 }
 
+// Gtxdatazero 4 Paid for every zero byte of data or code for a transaction.
+// Gtxdatanonzero 68 Paid for every non-zero byte of data or code for a transaction
+// From yellow paper https://gavwood.com/paper.pdf
+// May change soon (EIP 2028: Transaction data gas cost reduction) https://eips.ethereum.org/EIPS/eip-2028
+function getCallDataGas(data) {
+  if (typeof data !== 'string') throw new Error('Data has to be a string');
+  if (data.startsWith('0x')) data = data.slice(2);
+  let gasCost = 0;
+  for (let i = 0; i < data.length; i += 2) {
+    if (data.substr(i, 2) === '00') {
+      gasCost += 4;
+    } else {
+      gasCost += 68;
+    }
+  }
+  return gasCost;
+}
+
 module.exports = {
   appendAddress,
   callAsJsonRpc,
@@ -190,4 +208,5 @@ module.exports = {
   createRelayHubFromRecipient,
   isRelayHubDeployedForRecipient,
   getRecipientFunds,
+  getCallDataGas,
 };

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,4 +1,4 @@
-const { getRecipientFunds, isRelayHubDeployedForRecipient } = require('../src/utils');
+const { getRecipientFunds, isRelayHubDeployedForRecipient, getCallDataGas } = require('../src/utils');
 const { setupAccounts, deployGreeter } = require('./setup');
 
 const expect = require('chai').use(require('chai-as-promised')).expect;
@@ -33,6 +33,24 @@ describe('utils', function() {
       await this.greeter.methods.setHub(this.deployer).send({ from: this.sender });
       const result = await isRelayHubDeployedForRecipient(this.web3, this.greeter.options.address);
       expect(result).to.be.false;
+    });
+  });
+
+  describe.only('#getCallDataGas', function() {
+    it('gets a valid CallData cost for long data', function() {
+      const gas = getCallDataGas(
+        '2ac0df260000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000b68656c6c6f20776f726c64000000000000000000000000000000000000000000',
+      );
+      expect(gas).to.be.eq(1488);
+    });
+    it('gets a valid CallData cost for simple data', function() {
+      let gas = getCallDataGas('0xaf');
+      expect(gas).to.be.eq(68);
+      gas = getCallDataGas('00');
+      expect(gas).to.be.eq(4);
+    });
+    it('throws if data not a string', function() {
+      expect(() => getCallDataGas({ data: '0x00' })).to.throw(/Data has to be a string/);
     });
   });
 });


### PR DESCRIPTION
Fix [issue](https://github.com/tabookey/tabookey-gasless/issues/213) caused by `GSNDevProvider` not taking into account gas required for callData of `relayCall` method.
PS We also need to fix it for `GSNProvider by updating Go binaries cc @spalladino, @nventuro.