### PR TITLE
Constant register fix

### DIFF
--- a/src/dev/DevRelayClient.js
+++ b/src/dev/DevRelayClient.js
@@ -39,8 +39,7 @@ class DevRelayClient {
     // Start by registering in the relayer hub
     const txParams = payload.params[0];
     const hub = await createRelayHubFromRecipient(this.web3, txParams.to);
-    const isNotRegistered = !(await this.isRegistered(hub))
-    if(isNotRegistered) {
+    if(!(await this.isRegistered(hub))) {
       if (this.debug) console.log(`Relayer is not registered yet. Registering...`);
       await this.register(hub);
     }
@@ -190,6 +189,7 @@ class DevRelayClient {
     try {
       currentStake = (await hub.methods.getRelay(this.relayerAddress).call()).totalStake;
     } catch (err) {
+      console.error(`Error getting current relayer stake ${err.message}`)
       currentStake = 0;
     }
     return new BN(currentStake);
@@ -200,6 +200,7 @@ class DevRelayClient {
     try {
       currentState = (await hub.methods.getRelay(this.relayerAddress).call()).state;
     } catch (err) {
+      console.error(`Error getting current relayer state ${err.message}`)
       currentState = 0;
     }
     return Number(currentState) === RELAY_STATE.Registered;


### PR DESCRIPTION
This PR enhance `GSNDevProvider` logic by checking if the relayer already registered. If so, there is no reason to make it again - tabookey relay does not do that before every tx, right? Moreover, such behavior violates the default assumption that calling a contract method is an atomic action, which causes problems with unit tests.