### PR TITLE
Predefined relay

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ const {
   makeApproveFunction,
   getRecipientFunds,
   isRelayHubDeployedForRecipient,
+  createRelayHub
 } = require('./utils');
 
 module.exports = {

--- a/src/index.js
+++ b/src/index.js
@@ -19,5 +19,6 @@ module.exports = {
     makeApproveFunction,
     getRecipientFunds,
     isRelayHubDeployedForRecipient,
+    createRelayHub
   },
 };

--- a/src/tabookey-gasless/RelayClient.js
+++ b/src/tabookey-gasless/RelayClient.js
@@ -51,7 +51,17 @@ class RelayClient {
    *          Note that the resulting gasPrice must be accepted by relay (above its minGasPrice)
    *
    *manual settings: these can be used to override the default setting.
-   *    relayUrl, relayAddress - avoid lookup on relayHub for relays, and always use this URL/address
+   *    predefinedRelay - avoid lookup on relayHub for relays, and always use this predefined relay. 
+   *       An example of `predefinedRelay` Object :
+   *        {
+   *          RelayServerAddress: '0x73a652f54d5fd8273f17a28e206d47f5bd1bc06a',
+   *          MinGasPrice: 20000000000,
+   *          Ready: true,
+   *          Version: '0.4.1',
+   *          relayUrl: 'http://localhost:8090',
+   *          transactionFee: '70' 
+   *        }
+   *       It could be retrieved from `/getaddr` of a relayer. e.g `curl http://localhost:8090/getaddr`
    *    force_gasLimit - force gaslimit, instead of transaction paramter
    *    force_gasPrice - force gasPrice, instread of transaction parameter.
    */
@@ -399,7 +409,12 @@ class RelayClient {
     let pinger = await this.serverHelper.newActiveRelayPinger(blockFrom, gasPrice);
     let errors = [];
     for (;;) {
-      let activeRelay = await pinger.nextRelay();
+      let activeRelay
+      if (self.config.predefinedRelay) {
+        activeRelay = self.config.predefinedRelay;
+      } else {
+        activeRelay = await pinger.nextRelay();
+      }
       if (!activeRelay) {
         const subErrors = errors.concat(pinger.errors);
         const error = new Error(

--- a/src/tabookey-gasless/RelayClient.js
+++ b/src/tabookey-gasless/RelayClient.js
@@ -55,9 +55,6 @@ class RelayClient {
    *       An example of `predefinedRelay` Object :
    *        {
    *          RelayServerAddress: '0x73a652f54d5fd8273f17a28e206d47f5bd1bc06a',
-   *          MinGasPrice: 20000000000,
-   *          Ready: true,
-   *          Version: '0.4.1',
    *          relayUrl: 'http://localhost:8090',
    *          transactionFee: '70' 
    *        }

--- a/src/utils.js
+++ b/src/utils.js
@@ -209,4 +209,5 @@ module.exports = {
   isRelayHubDeployedForRecipient,
   getRecipientFunds,
   getCallDataGas,
+  createRelayHub
 };


### PR DESCRIPTION
This PR about two things.
1) First of all, `manual settings` for the tabookey RelayClient are broken. The options `relayUrl, relayAddress` passed to `GSNProvider` won't have any effect. So this PR allows GSNProvider to have `predefinedRelay` option for the same purpose - to avoid lookup on relayHub for relays, and always use this `predefinedRelay`
2) `createRelayHub` is so useful, so I decided to export it as well. (So that I can avoid importing the relay hub ABI to my project, cause it's already in GSNProvider)

[This](https://github.com/peppersec/tornado-mixer/blob/gsn/test/GSNsupport.test.js#L261-L271) is how it can be used in apps