### PR TITLE
canRelayFailed.find is not a function

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -59,7 +59,7 @@ function fixTransactionReceiptResponse(resp, debug = false) {
   };
 
   if (canRelayFailed) {
-    setErrorStatus(`canRelay failed with ${canRelayFailed.find(e => e.name == 'reason').value}`);
+    setErrorStatus(`canRelay failed with ${canRelayFailed.events.find(e => e.name == 'reason').value}`);
   } else if (transactionRelayed) {
     const status = transactionRelayed.events.find(e => e.name == 'status').value;
     if (parseInt(status) !== 0) {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,4 +1,9 @@
-const { getRecipientFunds, isRelayHubDeployedForRecipient, getCallDataGas } = require('../src/utils');
+const {
+  getRecipientFunds,
+  isRelayHubDeployedForRecipient,
+  getCallDataGas,
+  fixTransactionReceiptResponse,
+} = require('../src/utils');
 const { setupAccounts, deployGreeter } = require('./setup');
 
 const expect = require('chai').use(require('chai-as-promised')).expect;
@@ -51,6 +56,36 @@ describe('utils', function() {
     });
     it('throws if data not a string', function() {
       expect(() => getCallDataGas({ data: '0x00' })).to.throw(/Data has to be a string/);
+    });
+  });
+
+  describe('#fixTransactionReceiptResponse', function() {
+    it('gets result status 0 when canRelay fails', function() {
+      const respInput = {
+        result: {
+          logs: [
+            {
+              address: '0xd216153c06e857cd7f72665e0af1d7d82172f494',
+              blockHash: '0x5127fd656480d97fab7d2c3300d3e92452765c48bbc16ec6e67d61203e3e0650',
+              blockNumber: '0x57da45',
+              data:
+                '0x9e80c074000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002',
+              logIndex: '0x14',
+              removed: false,
+              topics: [
+                '0xafb5afd6d1c2e8ffbfb480e674a169f493ece0b22658d4f4484e7334f0241e22',
+                '0x000000000000000000000000eb3e8ad0c83d5e5c8af7ad073d5dd5b1507d73f8',
+                '0x00000000000000000000000002d9123692a15bd08bf151154c6f2a47cd1b4040',
+                '0x000000000000000000000000f49f5f2458f27b3e52d0755bfac623877b1fc3f5',
+              ],
+              transactionHash: '0x0836aa8f15336f1a203c4c57170fe0d77d389bcf37d2dd6c0238e378f4c2cc36',
+              transactionIndex: '0x5',
+            },
+          ],
+        },
+      };
+      const respOutput = fixTransactionReceiptResponse(respInput);
+      expect(respOutput.result.status).to.be.eq(0);
     });
   });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -72,7 +72,7 @@ describe('utils', function() {
                 '0x9e80c074000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002',
               logIndex: '0x14',
               removed: false,
-              topics: [
+              topics: [ // These include a CanRelayFailed event
                 '0xafb5afd6d1c2e8ffbfb480e674a169f493ece0b22658d4f4484e7334f0241e22',
                 '0x000000000000000000000000eb3e8ad0c83d5e5c8af7ad073d5dd5b1507d73f8',
                 '0x00000000000000000000000002d9123692a15bd08bf151154c6f2a47cd1b4040',


### PR DESCRIPTION
Can relay object looks like this:
{ name: 'CanRelayFailed',
  events:
   [ { name: 'relay',
       type: 'address',
       value: '0x62a96edc3af17b1dd168b53c9e2ec947dae5c9ff' },
     { name: 'from',
       type: 'address',
       value: '0xc6e831aa742f78bbd7c8f13d8810b0140607facf' },
     { name: 'to',
       type: 'address',
       value: '0xf49f5f2458f27b3e52d0755bfac623877b1fc3f5' },
     { name: 'selector', type: 'bytes4', value: '0x9e80c074' },
     { name: 'reason', type: 'uint256', value: '2' } ],
  address: '0xd216153c06e857cd7f72665e0af1d7d82172f494' }

The iterable array is "events"