### PR TITLE
Stop sending invalid parameters over JSON RPC

### DIFF
--- a/src/tabookey-gasless/RelayClient.js
+++ b/src/tabookey-gasless/RelayClient.js
@@ -386,7 +386,8 @@ class RelayClient {
       if (!gasLimit)
         gasLimit = await this.estimateGas(
           {
-            ...options,
+            to: options.to,
+            from: options.from,
             gasPrice,
             data: encodedFunctionCall,
           },


### PR DESCRIPTION
Fixes an issue [reported on the forum](https://forum.openzeppelin.com/t/network-js-gsn-error-unknown-field-gas-price/2392) where certain requests would fail depending on the endpoint. This was reproduced by @abcoathup.

Apparently, Parity is less permissive than Geth: it will fail if a JSON-RPC request contains invalid arguments, while Geth silently ignores them.

The bug is caused by `relayTransaction`'s `option` argument not being a transaction options object, but instead _relay request options_ (obtained via the confusingly named `getTransactionOptions`), which includes fields such as `txfee`, `approveFunction`, and critically, `gas_price`: `eth_sendTransaction`'s argument is called `gasPrice`, not `gas_price`.

While the `gasPrice` field is correctly computed on line 375, the entire `options` object is still being passed along with the other options: this causes non-existent fields to be sent along. Since the only ones we need are `to` and `from`, the fix is rather simple.